### PR TITLE
remove :bt package nickname from cl_bullet

### DIFF
--- a/bullet_reasoning/src/package.lisp
+++ b/bullet_reasoning/src/package.lisp
@@ -32,7 +32,7 @@
 
 (desig-props:def-desig-package bullet-reasoning
   (:nicknames :btr)
-  (:use #:common-lisp #:crs #:bt #:bt-vis #:cut #:cram-manipulation-knowledge)
+  (:use #:common-lisp #:crs #:bullet #:bt-vis #:cut #:cram-manipulation-knowledge)
   (:import-from #:alexandria compose curry rcurry with-gensyms copy-hash-table)
   (:import-from #:desig desig-solutions)
   (:shadowing-import-from #:cl-bullet points)

--- a/bullet_reasoning_designators/src/costmap-generators.lisp
+++ b/bullet_reasoning_designators/src/costmap-generators.lisp
@@ -30,9 +30,9 @@
 
 (defun make-object-bounding-box-costmap-generator (object)
   (let* ((bounding-box (aabb object))
-         (dimensions-x/2 (/ (cl-transforms:x (bt:bounding-box-dimensions bounding-box))
+         (dimensions-x/2 (/ (cl-transforms:x (bullet:bounding-box-dimensions bounding-box))
                             2))
-         (dimensions-y/2 (/ (cl-transforms:y (bt:bounding-box-dimensions bounding-box))
+         (dimensions-y/2 (/ (cl-transforms:y (bullet:bounding-box-dimensions bounding-box))
                             2)))
     (lambda (x y)
       (if (and

--- a/bullet_reasoning_designators/src/location-designator-integration.lisp
+++ b/bullet_reasoning_designators/src/location-designator-integration.lisp
@@ -130,10 +130,10 @@ that `designator' tries to reach."
         ((let ((cached-function
                  (or (gethash designator *designator-ik-check-cache*)
                      (setf (gethash designator *designator-ik-check-cache*)
-                           (let* ((state (bt:get-state *current-bullet-world*))
+                           (let* ((state (bullet:get-state *current-bullet-world*))
                                   (world (bullet:restore-world-state
                                           state (make-instance 'btr:bt-reasoning-world
-                                                  :gravity-vector (bt:gravity-vector state))))
+                                                  :gravity-vector (bullet:gravity-vector state))))
                                   (robot (btr:object world (get-robot-name))))
                              (make-ik-check-function
                               robot (pose-side-properties designator)))))))

--- a/bullet_reasoning_designators/src/visibility-costmap.lisp
+++ b/bullet_reasoning_designators/src/visibility-costmap.lisp
@@ -244,7 +244,7 @@ square depth image of size `pixels' and the index of the depth image."
                                        (objects world))))
     (visibility-costmap
      (btr:make-drawable-list :drawables objects-to-render)
-     (bt:pose object) camera-minimal-height camera-maximal-height
+     (bullet:pose object) camera-minimal-height camera-maximal-height
      size resolution)))
 
 (defun visibility-costmap (drawable pose camera-minimal-height camera-maximal-height size resolution)

--- a/cl_bullet/src/lisp/bt-world.lisp
+++ b/cl_bullet/src/lisp/bt-world.lisp
@@ -28,7 +28,7 @@
 ;;; POSSIBILITY OF SUCH DAMAGE.
 ;;;
 
-(in-package :bt)
+(in-package :bullet)
 
 (defgeneric gravity-vector (world))
 (defgeneric (setf gravity-vector) (new-value world))

--- a/cl_bullet/src/lisp/cffi.lisp
+++ b/cl_bullet/src/lisp/cffi.lisp
@@ -28,7 +28,7 @@
 ;;; POSSIBILITY OF SUCH DAMAGE.
 ;;;
 
-(in-package :bt)
+(in-package :bullet)
 
 (define-foreign-ros-library bullet-cl "libbullet_cl.so")
 

--- a/cl_bullet/src/lisp/collision-shapes.lisp
+++ b/cl_bullet/src/lisp/collision-shapes.lisp
@@ -28,7 +28,7 @@
 ;;; POSSIBILITY OF SUCH DAMAGE.
 ;;;
 
-(in-package :bt)
+(in-package :bullet)
 
 (defclass collision-shape (foreign-class) ())
 

--- a/cl_bullet/src/lisp/constraints.lisp
+++ b/cl_bullet/src/lisp/constraints.lisp
@@ -28,7 +28,7 @@
 ;;; POSSIBILITY OF SUCH DAMAGE.
 ;;;
 
-(in-package :bt)
+(in-package :bullet)
 
 (defclass constraint (foreign-class)
   ((body-1 :initarg :body-1 :reader body-1)

--- a/cl_bullet/src/lisp/contact-manifold.lisp
+++ b/cl_bullet/src/lisp/contact-manifold.lisp
@@ -28,7 +28,7 @@
 ;;; POSSIBILITY OF SUCH DAMAGE.
 ;;;
 
-(in-package :bt)
+(in-package :bullet)
 
 (defclass contact-point ()
   ((point-in-1 :initarg :point-in-1 :reader point-in-1)

--- a/cl_bullet/src/lisp/foreign-class.lisp
+++ b/cl_bullet/src/lisp/foreign-class.lisp
@@ -28,7 +28,7 @@
 ;;; POSSIBILITY OF SUCH DAMAGE.
 ;;;
 
-(in-package :bt)
+(in-package :bullet)
 
 (defclass foreign-class ()
   ((foreign-obj :reader foreign-obj)))

--- a/cl_bullet/src/lisp/hinge-constraint.lisp
+++ b/cl_bullet/src/lisp/hinge-constraint.lisp
@@ -28,7 +28,7 @@
 ;;; POSSIBILITY OF SUCH DAMAGE.
 ;;;
 
-(in-package :bt)
+(in-package :bullet)
 
 (defclass hinge-constraint (constraint)
   ((frame-in-1 :initform (cl-transforms:make-transform

--- a/cl_bullet/src/lisp/motion-state.lisp
+++ b/cl_bullet/src/lisp/motion-state.lisp
@@ -28,7 +28,7 @@
 ;;; POSSIBILITY OF SUCH DAMAGE.
 ;;;
 
-(in-package :bt)
+(in-package :bullet)
 
 (defgeneric pose (obj)
   (:documentation "Returns the pose of `obj'"))

--- a/cl_bullet/src/lisp/package.lisp
+++ b/cl_bullet/src/lisp/package.lisp
@@ -29,7 +29,7 @@
 ;;;
 
 (defpackage cl-bullet
-    (:nicknames :bullet :bt)
+    (:nicknames :bullet)
   (:use #:common-lisp #:cffi #:cffi-ros-utils)
   (:export
    ;; dynamics world

--- a/cl_bullet/src/lisp/point-2-point-constraint.lisp
+++ b/cl_bullet/src/lisp/point-2-point-constraint.lisp
@@ -28,7 +28,7 @@
 ;;; POSSIBILITY OF SUCH DAMAGE.
 ;;;
 
-(in-package :bt)
+(in-package :bullet)
 
 (defclass point-2-point-constraint (constraint)
   ((point-in-1 :initform (cl-transforms:make-3d-vector 0 0 0)

--- a/cl_bullet/src/lisp/rigid-body.lisp
+++ b/cl_bullet/src/lisp/rigid-body.lisp
@@ -28,7 +28,7 @@
 ;;; POSSIBILITY OF SUCH DAMAGE.
 ;;;
 
-(in-package :bt)
+(in-package :bullet)
 
 (defstruct bounding-box
   (center (cl-transforms:make-3d-vector 0 0 0))

--- a/cl_bullet/src/lisp/slider-constraint.lisp
+++ b/cl_bullet/src/lisp/slider-constraint.lisp
@@ -28,7 +28,7 @@
 ;;; POSSIBILITY OF SUCH DAMAGE.
 ;;;
 
-(in-package :bt)
+(in-package :bullet)
 
 (defclass slider-constraint (constraint)
   ((frame-in-1 :initform (cl-transforms:make-transform

--- a/cl_bullet/src/lisp/world-state.lisp
+++ b/cl_bullet/src/lisp/world-state.lisp
@@ -28,7 +28,7 @@
 ;;; POSSIBILITY OF SUCH DAMAGE.
 ;;;
 
-(in-package :bt)
+(in-package :bullet)
 
 (defgeneric get-state (obj)
   (:documentation "Returns a state object that allows to completely

--- a/cl_bullet_vis/examples/package.lisp
+++ b/cl_bullet_vis/examples/package.lisp
@@ -30,5 +30,5 @@
 
 (defpackage bullet-visualization-examples
     (:nicknames :bt-vis-ex)
-  (:use #:common-lisp #:bt #:bt-vis)
+  (:use #:common-lisp #:bullet #:bt-vis)
   (:export))

--- a/cl_bullet_vis/src/package.lisp
+++ b/cl_bullet_vis/src/package.lisp
@@ -32,7 +32,7 @@
 
 (defpackage cl-bullet-vis
     (:nicknames :bt-vis)
-  (:use #:common-lisp #:bt)
+  (:use #:common-lisp #:bullet)
   (:import-from #:physics-utils
                 event-queue post-event get-next-event)
   (:export bullet-world-window world camera-transform

--- a/cram_environment_representation/src/event-handlers.lisp
+++ b/cram_environment_representation/src/event-handlers.lisp
@@ -140,7 +140,7 @@
      'desig-props:location
      `((pose ,(tf:pose->pose-stamped
                designators-ros:*fixed-frame* (cut:current-timestamp)
-               (bt:pose object)))))))
+               (bullet:pose object)))))))
 
 (defun make-object-location-in-gripper (object gripper-link)
   "Returns a new location designator that indicates a location in the

--- a/pr2_projection_process_modules/src/projection-environment.lisp
+++ b/pr2_projection_process_modules/src/projection-environment.lisp
@@ -37,7 +37,7 @@
 (define-projection-environment pr2-bullet-projection-environment
   :special-variable-initializers
   ((cram-roslisp-common:*tf* (make-instance 'tf:transformer))
-   ;; (*current-bullet-world* (bt:copy-world *current-bullet-world*))
+   ;; (*current-bullet-world* (bullet:copy-world *current-bullet-world*))
    (*current-timeline* (btr:timeline-init *current-bullet-world*))
    (desig:*default-role* 'projection-role)
    (*projection-clock* (make-instance 'partially-ordered-clock))

--- a/spatial_relations_costmap/src/cost-functions.lisp
+++ b/spatial_relations_costmap/src/cost-functions.lisp
@@ -36,17 +36,17 @@
 
 ;; used for near and far-from desig-props
 (defun get-aabb-min-length (object)
-  (let* ((dims (bt:bounding-box-dimensions (aabb object))))
+  (let* ((dims (bullet:bounding-box-dimensions (aabb object))))
     (min (cl-transforms:x dims) (cl-transforms:y dims))))
 
 ;; used for near and far-from desig-props
 (defun get-aabb-circle-diameter (object)
-  (cl-transforms:x (bt:bounding-box-dimensions (aabb object))))
+  (cl-transforms:x (bullet:bounding-box-dimensions (aabb object))))
 
 ;; used for near and far-from desig-props
 ;; we assume the radius of the oval is the max of its two radia
 (defun get-aabb-oval-diameter (object)
-  (let ((dims (bt:bounding-box-dimensions (aabb object))))
+  (let ((dims (bullet:bounding-box-dimensions (aabb object))))
     (max (cl-transforms:x dims) (cl-transforms:y dims))))
 
 ;; used for near desig-prop
@@ -192,10 +192,10 @@
           (dolist (bounding-box aabbs (if invert 1.0d0 0.0d0))
             (let* ((bb-center (cl-bullet:bounding-box-center bounding-box))
                    (dimensions-x/2
-                     (+ (/ (cl-transforms:x (bt:bounding-box-dimensions bounding-box)) 2)
+                     (+ (/ (cl-transforms:x (bullet:bounding-box-dimensions bounding-box)) 2)
                         padding))
                    (dimensions-y/2
-                     (+ (/ (cl-transforms:y (bt:bounding-box-dimensions bounding-box)) 2)
+                     (+ (/ (cl-transforms:y (bullet:bounding-box-dimensions bounding-box)) 2)
                         padding)))
               (when (and
                      (< x (+ (cl-transforms:x bb-center) dimensions-x/2))

--- a/spatial_relations_costmap/src/prolog.lisp
+++ b/spatial_relations_costmap/src/prolog.lisp
@@ -336,7 +336,7 @@
     (object-shape ?world ?obj-name ?shape)
     (%object ?world ?obj-name ?obj)
     (lisp-fun aabb ?obj ?aabb)
-    (lisp-fun bt:bounding-box-dimensions ?aabb ?dims)
+    (lisp-fun bullet:bounding-box-dimensions ?aabb ?dims)
     (%object-size-without-handles ?world ?obj ?shape ?size))
   ;;
   (<- (%object-size-without-handles ?world ?obj ?shape ?size)


### PR DESCRIPTION
We are using a 3rd party library which pulls in bordeaux-threads (nickname :bt), which lead to a naming conflict with cl_bullet (also having :bt as nickname). As bordeaux seems to be somewhat popular, I propose to remove the :bt nickname from cl_bullet and use the :bullet package name for cl_bullet.
