### PR TITLE
added fixes for older bullet versions in hydro

### DIFF
--- a/cl_bullet/src/dynamics_world.cpp
+++ b/cl_bullet/src/dynamics_world.cpp
@@ -195,12 +195,12 @@ extern "C"
 
   const btCollisionObject *manifoldGetBody0(btPersistentManifold *manifold)
   {
-    return manifold->getBody0();
+    return reinterpret_cast<const btCollisionObject *>(manifold->getBody0());
   }
 
   const btCollisionObject *manifoldGetBody1(btPersistentManifold *manifold)
   {
-    return manifold->getBody1();
+    return reinterpret_cast<const btCollisionObject *>(manifold->getBody1());
   }
 
   int manifoldGetNumContactPoints(btPersistentManifold *manifold)


### PR DESCRIPTION
Adding these fixes for older bullet versions allows working with two versions. The older one and the newer one.
