### PR TITLE
URDF-SEMANTIC-MAP-OBJECT copy constructor

### DIFF
--- a/bullet_reasoning/src/semantic-map.lisp
+++ b/bullet_reasoning/src/semantic-map.lisp
@@ -50,11 +50,18 @@
                :format-arguments (list part-name)))
       (sem-map-utils:pose part))))
 
-(defmethod copy-object ((obj semantic-map-object) (world bt-reasoning-world))
-  (with-slots (semantic-map link-offsets) obj
-    (change-class
-     (call-next-method) 'semantic-map-object
-     :semantic-map (sem-map-utils:copy-semantic-map-object semantic-map))))
+;; (defmethod copy-object ((obj semantic-map-object) (world bt-reasoning-world))
+;;   (with-slots (semantic-map) obj
+;;     (change-class
+;;      (call-next-method) 'semantic-map-object
+;;      :semantic-map (sem-map-utils:copy-semantic-map-object semantic-map))))
+;; For multiple inheritance objects of class URDF-SEMANTIC-MAP-OBJECT this function
+;; discards all the slots of its ROBOT-OBJECT when changing the class to
+;; SEMANTIC-MAP-OBJECT. Therefore, and considering that SEMANTIC-MAP-OBJECT
+;; only appears in bullet world as a URDF-SEMANTIC-MAP-OBJECT
+;; or maybe SIMPLE-SEMANTIC-MAP-OBJECT and it is itself
+;; only a mixin, it makes more sense to define COPY-OBJECT directly on the
+;; URDF-SEMANTIC-MAP-OBJECT and SIMPLE-SEMANTIC-MAP-OBJECT classes.
 
  (defmethod add-object ((world bt-world) (type (eql 'semantic-map)) name pose &key urdf)
    (if urdf

--- a/bullet_reasoning/src/simple-semantic-map.lisp
+++ b/bullet_reasoning/src/simple-semantic-map.lisp
@@ -46,6 +46,12 @@
       (initialize-rigid-bodies semantic-map-object bodies)
       (setf pose-reference-body (car bodies)))))
 
+(defmethod copy-object ((obj simple-semantic-map-object) (world bt-reasoning-world))
+  (with-slots (semantic-map) obj
+    (change-class
+     (call-next-method) 'simple-semantic-map-object
+     :semantic-map (sem-map-utils:copy-semantic-map-object semantic-map))))
+
 (defgeneric semantic-map-part-ridig-body (part &key pose collision-group collision-mask)
   (:documentation "Returns a rigid body for the semantic map part `part'.")
   (:method ((part sem-map-utils:semantic-map-geom) &key pose collision-group collision-mask)

--- a/bullet_reasoning/src/simple-semantic-map.lisp
+++ b/bullet_reasoning/src/simple-semantic-map.lisp
@@ -37,7 +37,7 @@
   (with-slots (pose-reference-body semantic-map) semantic-map-object
     (let ((bodies (loop for part in (sem-map-utils:semantic-map-parts
                                      semantic-map :recursive t)
-                        for body = (semantic-map-part-ridig-body
+                        for body = (semantic-map-part-rigid-body
                                     part
                                     :pose pose
                                     :collision-group collision-group
@@ -52,7 +52,7 @@
      (call-next-method) 'simple-semantic-map-object
      :semantic-map (sem-map-utils:copy-semantic-map-object semantic-map))))
 
-(defgeneric semantic-map-part-ridig-body (part &key pose collision-group collision-mask)
+(defgeneric semantic-map-part-rigid-body (part &key pose collision-group collision-mask)
   (:documentation "Returns a rigid body for the semantic map part `part'.")
   (:method ((part sem-map-utils:semantic-map-geom) &key pose collision-group collision-mask)
     (make-instance 'rigid-body


### PR DESCRIPTION
It had no copy constructor, so the one from its parent SEMANTIC-MAP-OBJECT was used which made it omit all the URDF-related slots. That was creating bugs when copying the bullet world.

Also, a minor typo fix.
